### PR TITLE
Add rustfmt settings

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,13 @@
+binop_separator = "Back"
+brace_style = "SameLineWhere"
+force_multiline_blocks = true
+format_strings = false
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+imports_layout = "HorizontalVertical"
+match_block_trailing_comma = false
+max_width = 80
+reorder_impl_items = true
+reorder_imports = true
+struct_field_align_threshold = 16
+use_field_init_shorthand = true


### PR DESCRIPTION
rustfmt is good at automatically keeping a consistent format.  These are the settings that I personally like, though you may prefer differently. In particular, the 80 column line width is not very popular among Rust developers, who mostly prefer 100 columns.