### PR TITLE
Fix CI on Linux

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -56,7 +56,6 @@ task:
   setup_script:
     - apt-get update
     - apt-get install -y zstd libfuse3-dev fuse kmod
-    - modprobe fuse
   << : *TEST
   before_cache_script: rm -rf $HOME/.cargo/registry/index
 


### PR DESCRIPTION
Don't try to load fuse.  It isn't a module.
    
Fixes #11