### PR TITLE
run(): don't use inspect_err(), as it required newer Rust

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -51,7 +51,7 @@ task:
 task:
   name: Linux MSRV
   container:
-    image: rust:1.77.0
+    image: rust:1.74.1
     kvm: true
   setup_script:
     - apt-get update

--- a/src/ufs.rs
+++ b/src/ufs.rs
@@ -146,8 +146,10 @@ impl Ufs {
 }
 
 fn run<T>(f: impl FnOnce() -> IoResult<T>) -> Result<T, c_int> {
-	f().inspect_err(|e| log::error!("Error: {e}"))
-		.map_err(|e| e.raw_os_error().unwrap_or(libc::EIO))
+	f().map_err(|e| {
+		log::error!("Error: {e}");
+		e.raw_os_error().unwrap_or(libc::EIO)
+	})
 }
 
 fn transino(ino: u64) -> u64 {


### PR DESCRIPTION
The version of Rust on FreeBSD/powerpc64 is 1.74.1.